### PR TITLE
make /tmp a tmpfs

### DIFF
--- a/etc/fstab
+++ b/etc/fstab
@@ -12,4 +12,3 @@ UUID=379ef707-e23e-473a-a082-cc924e1b70ab /boot           ext2    defaults      
 /dev/mapper/vg0-lv1 none            swap    sw,nosuid,noexec,nodev              0       0
 /dev/sr0        /media/cdrom0   udf,iso9660 user,noauto     0       0
 tmpfs		/tmp		tmpfs	rw,nodev,nosuid,noexec	0	0
-/tmp		/var/tmp	none	rw,nodev,nosuid,noexec,bind	0	0


### PR DESCRIPTION
This will make /tmp/ a tmpfs directory with nosuid, nodev and noexec options (for security purposes).

In case (hopefully never again) the root file system suffers from an error and becomes unreadable, this will at least ensure a degree of usability. Not to mention the performance gain for applications not using the actual disk for tmpfs.
