### PR TITLE
hashbang: remove pgp.mit.edu from keyserver list

### DIFF
--- a/ansible/tasks/hashbang/main.yml
+++ b/ansible/tasks/hashbang/main.yml
@@ -10,8 +10,7 @@
         for server in $(shuf -e ha.pool.sks-keyservers.net \
                                 hkp://p80.pool.sks-keyservers.net:80 \
                                 keyserver.ubuntu.com \
-                                hkp://keyserver.ubuntu.com:80 \
-                                pgp.mit.edu ) ; \
+                                hkp://keyserver.ubuntu.com:80 ) ; \
         do \
           gpg --keyserver "$server" --recv-keys "{{ item }}" && break || : ; \
         done


### PR DESCRIPTION
pgp.mit.edu is slow and almost unusable for me, removing it will make the key-importing a little bit faster.