### PR TITLE
Ansible: Use systematically the systemd module

### DIFF
--- a/ansible/tasks/dns/main.yml
+++ b/ansible/tasks/dns/main.yml
@@ -50,23 +50,15 @@
         server:
             qname-minimisation: yes
 
-- name: enable unbound service
-  command: systemctl enable unbound
-  # workaround for systemd module expecting running systemd
-  #systemd:
-  #  name: unbound
-  #  enabled: yes
+- name: Enable & reload services
+  when: not dockerenv.stat.exists
+  systemd:
+    name: "{{ item }}"
+    enabled: yes
+    masked: no
+    state: reloaded  # TODO: This should be a handler instead
 
-- name: enable resolvconf
-  command: systemctl enable resolvconf
-  # workaround for systemd module expecting running systemd
-  #systemd:
-  #  name: resolvconf
-  #  enabled: yes
-
-- name: enable unbound-resolvconf
-  command: systemctl enable unbound-resolvconf
-  # workaround for systemd module expecting running systemd
-  #systemd:
-  #  name: unbound-resolvconf
-  #  enabled: yes
+  with_items:
+    - unbound
+    - unbound-resolvconf
+    - resolvconf

--- a/ansible/tasks/hashbang/main.yml
+++ b/ansible/tasks/hashbang/main.yml
@@ -104,17 +104,12 @@
 
             [Install]
             WantedBy=timers.target
-      - command: systemctl enable ansible-pull.service
-      - command: systemctl enable ansible-pull.timer
-      - systemd:
-          name: ansible-pull.service
-          daemon_reload: true
-        ignore_errors: true
       - systemd:
           name: ansible-pull.timer
           state: started
-          daemon_reload: true
-        ignore_errors: true
+          enable: yes
+          daemon_reload: yes
+        ignore_errors: yes
 
 - name: Install Welcome Templates and Man page
   block:

--- a/ansible/tasks/misc/main.yml
+++ b/ansible/tasks/misc/main.yml
@@ -64,11 +64,11 @@
       mkfs.ext4 /dev/sda2
 
 - name: enable getty
-  command: systemctl enable getty@tty1
-  # workaround for systemd module expecting running systemd
-  # systemd:
-  #   name: getty@tty1
-  #   enabled: yes
+  when: not dockerenv.stat.exists
+  systemd:
+    name: getty@tty1
+    enabled: yes
+
 
 - name: Setup cron job to kill processes of stale accounts
   copy:

--- a/ansible/tasks/tor/main.yml
+++ b/ansible/tasks/tor/main.yml
@@ -23,9 +23,9 @@
     line: "AllowInbound 1"
 
 - name: enable tor service
-  command: systemctl enable tor
-  # workaround for systemd module expecting running systemd
-  #systemd:
-  #  name: tor
-  #  enabled: yes
-  #  masked: no
+  systemd:
+    name: tor
+    enabled: yes
+    masked: no
+    state: started
+  when: not dockerenv.stat.exists


### PR DESCRIPTION
Just skip the task when running in Docker (since it's pointless to try and enable services there, as systemd won't run)