### PR TITLE
Update main.yml

### DIFF
--- a/ansible/tasks/packages/main.yml
+++ b/ansible/tasks/packages/main.yml
@@ -249,6 +249,7 @@
       - lftp
       - libpam-systemd
       - libsqlite3-dev
+      - libcurl4-gnutls-dev
       - linux-image-amd64
       - lm-sensors
       - locales


### PR DESCRIPTION
libcurl4-gnutls-dev package  required for building php with curl support