### PR TITLE
remove `with_items` per deprecation warning

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -14,22 +14,21 @@
   - name: Install minimum system packages
     apt:
       update_cache: true
-      name: "{{ item }}"
-    with_items:
-    - ansible
-    - git
-    - gnupg
-    - apt-transport-https
-    - unattended-upgrades
-    - systemd
-    - apt-utils
-    - lsb-release
-    - curl
-    - initscripts
-    - systemd
-    - udev
-    - util-linux
-    - openssh-server
+      name: 
+        - ansible
+        - git
+        - gnupg
+        - apt-transport-https
+        - unattended-upgrades
+        - systemd
+        - apt-utils
+        - lsb-release
+        - curl
+        - initscripts
+        - systemd
+        - udev
+        - util-linux
+        - openssh-server
 
   - name: Remove undesirable apt files
     file:

--- a/ansible/tasks/nginx/main.yml
+++ b/ansible/tasks/nginx/main.yml
@@ -1,9 +1,8 @@
 ---
 - name: Install nginx
   apt:
-    name={{ item }}
-  with_items:
-    - nginx
+    name: 
+      - nginx
 
 - name: Setup sites-enabled/hashbang-http
   register: nginxconf

--- a/ansible/tasks/security/main.yml
+++ b/ansible/tasks/security/main.yml
@@ -42,10 +42,9 @@
 
 - name: Uninstall services with known PAM escapes
   apt:
-    name: "{{ item }}"
+    name:
+      - at
     state: absent
-  with_items:
-    - at
 
 - name: Disable services with known PAM escapes
   when: not dockerenv.stat.exists

--- a/ansible/tasks/tor/main.yml
+++ b/ansible/tasks/tor/main.yml
@@ -11,13 +11,12 @@
 
 - name: Install tor packages
   apt:
-    name: "{{ item }}"
-  with_items:
-    - deb.torproject.org-keyring
-    - python-torctl
-    - tor
-    - torsocks
-    - tor-arm
+    name:
+      - deb.torproject.org-keyring
+      - python-torctl
+      - tor
+      - torsocks
+      - tor-arm
 
 - name: setup torsocks to accept inbound connections
   lineinfile:


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via                                     
squash_actions is deprecated. Instead of using a loop to supply multiple items                              
and specifying `name: "{{ item }}"`, please use `name: ['nginx']` and remove                                
the loop. This feature will be removed in version 2.11. 
```

