### PR TITLE
Install yarn globally

### DIFF
--- a/ansible/tasks/profile/main.yml
+++ b/ansible/tasks/profile/main.yml
@@ -62,7 +62,7 @@
         command npm install -g npm
         command npm install -g n
         n "$1"
-        command npm install yarn
+        command npm install -g yarn
       }
 
       npm() {


### PR DESCRIPTION
Currently while running `install_node_version` `yarn` gets installed to the current working directory. 