### PR TITLE
ansible/tasks/hashbang: Use 15 minutes of downtime between ansible-pull invocations

### DIFF
--- a/ansible/tasks/hashbang/main.yml
+++ b/ansible/tasks/hashbang/main.yml
@@ -95,7 +95,7 @@
 
             [Timer]
             OnBootSec=15min
-            OnUnitActiveSec=15m
+            OnUnitDeactiveSec=15m
 
             [Install]
             WantedBy=timers.target


### PR DESCRIPTION
helps with not triggering the unit to run if it's still running. i don't think this happens. but just in case. no harm?