### PR TITLE
Add public key pinning in authorized-keys command

### DIFF
--- a/ansible/tasks/userdb/templates/usr/local/bin/authorized-keys.j2
+++ b/ansible/tasks/userdb/templates/usr/local/bin/authorized-keys.j2
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 user="$(id -u "$1")"
-curl -s "{{ userdb_apidomain }}/v1/ssh_public_key?uid=eq.$user&select=type,key" \
+curl --pinnedpubkey "QUfPGxRcqlRoehidvMEsF/R1Ee1MXkb3Sxw+MNTARdY=" -s "{{ userdb_apidomain }}/v1/ssh_public_key?uid=eq.$user&select=type,key" \
   | jq -r 'map(.type + " " + .key) | .[]'
 


### PR DESCRIPTION
This adds pubkey pinning so we don't need to trust the whole slew of CAs that come by default.

You probably want to:

1. Verify the pubkey is stable and doesn't change on renewal,
1. Structure this differently so the pubkey hash is a variable living somewhere else.